### PR TITLE
feat: api errors handling

### DIFF
--- a/packages/python/src/daytona_sdk/__init__.py
+++ b/packages/python/src/daytona_sdk/__init__.py
@@ -6,6 +6,7 @@ from .daytona import (
     Workspace,
     SessionExecuteRequest,
     SessionExecuteResponse,
+    DaytonaException
 )
 
 __all__ = [
@@ -15,5 +16,6 @@ __all__ = [
     "CodeLanguage",
     "Workspace",
     "SessionExecuteRequest",
-    "SessionExecuteResponse"
+    "SessionExecuteResponse",
+    "DaytonaException"
 ]

--- a/packages/python/src/daytona_sdk/_utils/exceptions.py
+++ b/packages/python/src/daytona_sdk/_utils/exceptions.py
@@ -1,0 +1,59 @@
+import json
+import functools
+from typing import Callable, Optional
+from daytona_api_client.exceptions import OpenApiException
+
+
+def intercept_exceptions(message_prefix: Optional[str] = ""):
+    """Decorator to intercept exceptions, process them, and optionally add a message prefix.
+    If the exception is an OpenApiException, it will be processed to extract the most meaningful exception message.
+
+    Args:
+        message_prefix (Optional[str]): Custom message prefix for the exception.
+    """
+    def decorator(func: Callable):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except OpenApiException as e:
+                message = _get_open_api_exception_message(e)
+
+                raise Exception(f"{message_prefix}{message}") from None
+            except Exception as e:
+                if message_prefix:
+                    message = f"{message_prefix}{str(e)}"
+                    raise e.__class__(message)
+                raise e
+
+        return wrapper
+    return decorator
+
+
+def _get_open_api_exception_message(exception: OpenApiException) -> str:
+    """Process API exceptions to extract the most meaningful error message.
+
+    This method examines the exception's body attribute and attempts to extract
+    the most informative error message using the following logic:
+    1. If the body is missing or empty, returns the original exception
+    2. If the body contains valid JSON with a 'message' field, uses that message
+    3. If the body is not valid JSON or does not contain a 'message' field, uses the raw body string
+
+    Args:
+        exception: The OpenApiException to process
+
+    Returns:
+        Exception with processed message
+    """
+    if not hasattr(exception, 'body') or not exception.body:
+        return str(exception)
+
+    body_str = str(exception.body)
+    try:
+        data = json.loads(body_str)
+        message = data.get('message', body_str) if isinstance(
+            data, dict) else body_str
+    except json.JSONDecodeError:
+        message = body_str
+
+    return message

--- a/packages/python/src/daytona_sdk/_utils/exceptions.py
+++ b/packages/python/src/daytona_sdk/_utils/exceptions.py
@@ -4,6 +4,11 @@ from typing import Callable, Optional
 from daytona_api_client.exceptions import OpenApiException
 
 
+class DaytonaException(Exception):
+    """Base exception for Daytona SDK."""
+    pass
+
+
 def intercept_exceptions(message_prefix: Optional[str] = ""):
     """Decorator to intercept exceptions, process them, and optionally add a message prefix.
     If the exception is an OpenApiException, it will be processed to extract the most meaningful exception message.
@@ -19,12 +24,12 @@ def intercept_exceptions(message_prefix: Optional[str] = ""):
             except OpenApiException as e:
                 message = _get_open_api_exception_message(e)
 
-                raise Exception(f"{message_prefix}{message}") from None
+                raise DaytonaException(f"{message_prefix}{message}") from None
             except Exception as e:
                 if message_prefix:
                     message = f"{message_prefix}{str(e)}"
-                    raise e.__class__(message)
-                raise e
+                    raise DaytonaException(message)
+                raise DaytonaException(str(e))
 
         return wrapper
     return decorator

--- a/packages/python/src/daytona_sdk/daytona.py
+++ b/packages/python/src/daytona_sdk/daytona.py
@@ -23,6 +23,7 @@ from daytona_sdk._utils.exceptions import intercept_exceptions
 from .code_toolbox.workspace_python_code_toolbox import WorkspacePythonCodeToolbox
 from .code_toolbox.workspace_ts_code_toolbox import WorkspaceTsCodeToolbox
 from .workspace import Workspace
+from daytona_sdk._utils.exceptions import DaytonaException
 
 
 # Type definitions
@@ -77,7 +78,7 @@ class Daytona:
             config: Optional DaytonaConfig object containing api_key, server_url, and target
 
         Raises:
-            ValueError: If API key or Server URL is not provided either through config or environment variables
+            DaytonaException: If API key or Server URL is not provided either through config or environment variables
         """
         if config is None:
             # Initialize env - it automatically reads from .env and .env.local
@@ -95,10 +96,10 @@ class Daytona:
             self.target = config.target
 
         if not self.api_key:
-            raise ValueError("API key is required")
+            raise DaytonaException("API key is required")
 
         if not self.server_url:
-            raise ValueError("Server URL is required")
+            raise DaytonaException("Server URL is required")
 
         # Create API configuration without api_key
         configuration = Configuration(host=self.server_url)
@@ -129,10 +130,10 @@ class Daytona:
 
         try:
             if params.timeout and params.timeout < 0:
-                raise ValueError("Timeout must be a non-negative number")
+                raise DaytonaException("Timeout must be a non-negative number")
             
             if params.auto_stop_interval is not None and params.auto_stop_interval < 0:
-                raise ValueError("auto_stop_interval must be a non-negative integer")
+                raise DaytonaException("auto_stop_interval must be a non-negative integer")
 
             # Create workspace using dictionary
             workspace_data = CreateWorkspace(
@@ -196,7 +197,7 @@ class Daytona:
             case "python":
                 return WorkspacePythonCodeToolbox()
             case _:
-                raise ValueError(f"Unsupported language: {params.language}")
+                raise DaytonaException(f"Unsupported language: {params.language}")
     
     @intercept_exceptions(message_prefix="Failed to remove workspace: ")
     def remove(self, workspace: Workspace) -> None:
@@ -219,10 +220,10 @@ class Daytona:
             Workspace: The workspace instance
 
         Raises:
-            ValueError: If workspace_id is not provided
+            DaytonaException: If workspace_id is not provided
         """
         if not workspace_id:
-            raise ValueError("workspace_id is required")
+            raise DaytonaException("workspace_id is required")
 
         # Get the workspace instance
         workspace_instance = self.workspace_api.get_workspace(workspace_id=workspace_id)
@@ -266,13 +267,13 @@ class Daytona:
             CodeLanguage: The validated language, defaults to "python" if None
             
         Raises:
-            ValueError: If the language is not supported
+            DaytonaException: If the language is not supported
         """
         if not language:
             return "python"
         
         if language not in ["python", "javascript", "typescript"]:
-            raise ValueError(f"Invalid code-toolbox-language: {language}")
+            raise DaytonaException(f"Invalid code-toolbox-language: {language}")
             
         return language  # type: ignore
     

--- a/packages/python/src/daytona_sdk/daytona.py
+++ b/packages/python/src/daytona_sdk/daytona.py
@@ -19,7 +19,7 @@ from daytona_api_client import (
     SessionExecuteRequest,
     SessionExecuteResponse
 )
-
+from daytona_sdk._utils.exceptions import intercept_exceptions
 from .code_toolbox.workspace_python_code_toolbox import WorkspacePythonCodeToolbox
 from .code_toolbox.workspace_ts_code_toolbox import WorkspaceTsCodeToolbox
 from .workspace import Workspace
@@ -109,6 +109,7 @@ class Daytona:
         self.workspace_api = WorkspaceApi(api_client)
         self.toolbox_api = ToolboxApi(api_client)
 
+    @intercept_exceptions(message_prefix="Failed to create workspace: ")
     def create(self, params: Optional[CreateWorkspaceParams] = None) -> Workspace:
         """Creates a new workspace and waits for it to start.
         
@@ -172,10 +173,10 @@ class Daytona:
 
         except Exception as e:
             try:
-                self.workspace_api.remove_workspace(workspace_id=workspace_id)
+                self.workspace_api.delete_workspace(workspace_id=workspace_id, force=True)
             except:
                 pass
-            raise Exception(f"Failed to create workspace: {str(e)}") from e
+            raise e
 
     def _get_code_toolbox(self, params: Optional[CreateWorkspaceParams] = None):
         """Helper method to get the appropriate code toolbox
@@ -196,7 +197,8 @@ class Daytona:
                 return WorkspacePythonCodeToolbox()
             case _:
                 raise ValueError(f"Unsupported language: {params.language}")
-            
+    
+    @intercept_exceptions(message_prefix="Failed to remove workspace: ")
     def remove(self, workspace: Workspace) -> None:
         """Removes a workspace.
         
@@ -205,6 +207,7 @@ class Daytona:
         """
         return self.workspace_api.delete_workspace(workspace_id=workspace.id, force=True)
 
+    @intercept_exceptions(message_prefix="Failed to get workspace: ")
     def get_current_workspace(self, workspace_id: str) -> Workspace:
         """
         Get a workspace by its ID.
@@ -233,7 +236,8 @@ class Daytona:
             self.toolbox_api,
             code_toolbox
         )
-    
+
+    @intercept_exceptions(message_prefix="Failed to list workspaces: ")
     def list(self) -> List[Workspace]:
         """List all workspaces."""
         workspaces = self.workspace_api.list_workspaces()

--- a/packages/python/src/daytona_sdk/filesystem.py
+++ b/packages/python/src/daytona_sdk/filesystem.py
@@ -15,6 +15,7 @@ from daytona_api_client import (
     Workspace as WorkspaceInstance,
     ToolboxApi,
 )
+from daytona_sdk._utils.exceptions import intercept_exceptions
 
 
 class FileSystem:
@@ -29,6 +30,7 @@ class FileSystem:
         self.instance = instance
         self.toolbox_api = toolbox_api
 
+    @intercept_exceptions(message_prefix="Failed to create folder: ")
     def create_folder(self, path: str, mode: str) -> None:
         """Creates a new folder in the workspace.
         
@@ -40,6 +42,7 @@ class FileSystem:
             workspace_id=self.instance.id, path=path, mode=mode
         )
 
+    @intercept_exceptions(message_prefix="Failed to delete file: ")
     def delete_file(self, path: str) -> None:
         """Deletes a file from the workspace.
         
@@ -50,6 +53,7 @@ class FileSystem:
             workspace_id=self.instance.id, path=path
         )
 
+    @intercept_exceptions(message_prefix="Failed to download file: ")
     def download_file(self, path: str) -> bytes:
         """Downloads a file from the workspace.
         
@@ -63,6 +67,7 @@ class FileSystem:
             workspace_id=self.instance.id, path=path
         )
 
+    @intercept_exceptions(message_prefix="Failed to find files: ")
     def find_files(self, path: str, pattern: str) -> List[Match]:
         """Searches for files matching a pattern.
         
@@ -77,6 +82,7 @@ class FileSystem:
             workspace_id=self.instance.id, path=path, pattern=pattern
         )
 
+    @intercept_exceptions(message_prefix="Failed to get file info: ")
     def get_file_info(self, path: str) -> FileInfo:
         """Gets detailed information about a file.
         
@@ -90,6 +96,7 @@ class FileSystem:
             workspace_id=self.instance.id, path=path
         )
 
+    @intercept_exceptions(message_prefix="Failed to list files: ")
     def list_files(self, path: str) -> List[FileInfo]:
         """Lists files and directories in a given path.
         
@@ -103,6 +110,7 @@ class FileSystem:
             workspace_id=self.instance.id, path=path
         )
 
+    @intercept_exceptions(message_prefix="Failed to move files: ")
     def move_files(self, source: str, destination: str) -> None:
         """Moves files from one location to another.
         
@@ -116,6 +124,7 @@ class FileSystem:
             destination=destination,
         )
 
+    @intercept_exceptions(message_prefix="Failed to replace in files: ")
     def replace_in_files(
         self, files: List[str], pattern: str, new_value: str
     ) -> List[ReplaceResult]:
@@ -137,6 +146,7 @@ class FileSystem:
             workspace_id=self.instance.id, replace_request=replace_request
         )
 
+    @intercept_exceptions(message_prefix="Failed to search files: ")
     def search_files(self, path: str, pattern: str) -> SearchFilesResponse:
         """Searches for files matching a pattern in their names.
         
@@ -151,6 +161,7 @@ class FileSystem:
             workspace_id=self.instance.id, path=path, pattern=pattern
         )
 
+    @intercept_exceptions(message_prefix="Failed to set file permissions: ")
     def set_file_permissions(
         self, path: str, mode: str = None, owner: str = None, group: str = None
     ) -> None:
@@ -170,6 +181,7 @@ class FileSystem:
             group=group,
         )
 
+    @intercept_exceptions(message_prefix="Failed to upload file: ")
     def upload_file(self, path: str, file: bytes) -> None:
         """Uploads a file to the workspace.
         

--- a/packages/python/src/daytona_sdk/git.py
+++ b/packages/python/src/daytona_sdk/git.py
@@ -16,6 +16,7 @@ from daytona_api_client import (
     GitCommitRequest,
     GitRepoRequest,
 )
+from daytona_sdk._utils.exceptions import intercept_exceptions
 
 if TYPE_CHECKING:
     from .workspace import Workspace
@@ -40,6 +41,7 @@ class Git:
         self.toolbox_api = toolbox_api
         self.instance = instance
 
+    @intercept_exceptions(message_prefix="Failed to add files: ")
     def add(self, path: str, files: List[str]) -> None:
         """Stages files for commit.
         
@@ -55,6 +57,7 @@ class Git:
             ),
         )
 
+    @intercept_exceptions(message_prefix="Failed to list branches: ")
     def branches(self, path: str) -> ListBranchResponse:
         """Lists branches in the repository.
         
@@ -69,6 +72,7 @@ class Git:
             path=path,
         )
 
+    @intercept_exceptions(message_prefix="Failed to clone repository: ")
     def clone(
         self,
         url: str,
@@ -100,6 +104,7 @@ class Git:
             )
         )
 
+    @intercept_exceptions(message_prefix="Failed to commit changes: ")
     def commit(self, path: str, message: str, author: str, email: str) -> None:
         """Commits staged changes.
         
@@ -119,6 +124,7 @@ class Git:
             ),
         )
 
+    @intercept_exceptions(message_prefix="Failed to push changes: ")
     def push(
         self, path: str, username: Optional[str] = None, password: Optional[str] = None
     ) -> None:
@@ -138,6 +144,7 @@ class Git:
             ),
         )
 
+    @intercept_exceptions(message_prefix="Failed to pull changes: ")
     def pull(
         self, path: str, username: Optional[str] = None, password: Optional[str] = None
     ) -> None:
@@ -157,6 +164,7 @@ class Git:
             ),
         )
 
+    @intercept_exceptions(message_prefix="Failed to get status: ")
     def status(self, path: str) -> GitStatus:
         """Gets the current Git repository status.
         

--- a/packages/python/src/daytona_sdk/lsp_server.py
+++ b/packages/python/src/daytona_sdk/lsp_server.py
@@ -15,6 +15,8 @@ from daytona_api_client import (
     LspDocumentRequest,
     LspCompletionParams
 )
+from daytona_sdk._utils.exceptions import intercept_exceptions
+
 
 LspLanguageId = Literal["typescript"]
 
@@ -53,6 +55,7 @@ class LspServer:
         self.toolbox_api = toolbox_api
         self.instance = instance
 
+    @intercept_exceptions(message_prefix="Failed to start LSP server: ")
     def start(self) -> None:
         """Starts the language server."""
         self.toolbox_api.lsp_start(
@@ -63,6 +66,7 @@ class LspServer:
             ),
         )
 
+    @intercept_exceptions(message_prefix="Failed to stop LSP server: ")
     def stop(self) -> None:
         """Stops the language server.
         
@@ -76,6 +80,7 @@ class LspServer:
             ),
         )
 
+    @intercept_exceptions(message_prefix="Failed to open file: ")
     def did_open(self, path: str) -> None:
         """Notifies the language server that a file has been opened.
         
@@ -94,6 +99,7 @@ class LspServer:
             ),
         )
 
+    @intercept_exceptions(message_prefix="Failed to close file: ")
     def did_close(self, path: str) -> None:
         """Notifies the language server that a file has been closed.
         
@@ -112,6 +118,7 @@ class LspServer:
             ),
         )
 
+    @intercept_exceptions(message_prefix="Failed to get symbols from document: ")
     def document_symbols(self, path: str) -> List[LspSymbol]:
         """Gets symbol information from a document.
         
@@ -128,6 +135,7 @@ class LspServer:
             uri=f"file://{path}",
         )
 
+    @intercept_exceptions(message_prefix="Failed to get symbols from workspace: ")
     def workspace_symbols(self, query: str) -> List[LspSymbol]:
         """Searches for symbols across the workspace.
         
@@ -144,6 +152,7 @@ class LspServer:
             query=query,
         )
 
+    @intercept_exceptions(message_prefix="Failed to get completions: ")
     def completions(self, path: str, position: Position) -> CompletionList:
         """Gets completion suggestions at a position in a file.
         

--- a/packages/python/src/daytona_sdk/process.py
+++ b/packages/python/src/daytona_sdk/process.py
@@ -17,6 +17,8 @@ from daytona_api_client import (
     CreateSessionRequest,
     Command
 )
+
+from daytona_sdk._utils.exceptions import intercept_exceptions
 from .code_toolbox.workspace_python_code_toolbox import WorkspacePythonCodeToolbox
 
 
@@ -39,6 +41,7 @@ class Process:
         self.toolbox_api = toolbox_api
         self.instance = instance
 
+    @intercept_exceptions(message_prefix="Failed to execute command: ")
     def exec(self, command: str, cwd: Optional[str] = None, timeout: Optional[int] = None) -> ExecuteResponse:
         """Executes a shell command in the workspace.
         
@@ -73,6 +76,7 @@ class Process:
         command = self.code_toolbox.get_run_command(code)
         return self.exec(command)
 
+    @intercept_exceptions(message_prefix="Failed to create session: ")
     def create_session(self, session_id: str) -> None:
         """Creates a new exec session in the workspace.
         
@@ -85,6 +89,7 @@ class Process:
             create_session_request=request
         )
 
+    @intercept_exceptions(message_prefix="Failed to get session: ")
     def get_session(self, session_id: str) -> Session:
         """Gets a session in the workspace.
         
@@ -98,7 +103,8 @@ class Process:
             workspace_id=self.instance.id,
             session_id=session_id
         )
-    
+
+    @intercept_exceptions(message_prefix="Failed to get session command: ")
     def get_session_command(self, session_id: str, command_id: str) -> Command:
         """Gets a command in the session.
         
@@ -115,6 +121,7 @@ class Process:
             command_id=command_id
         )
 
+    @intercept_exceptions(message_prefix="Failed to execute session command: ")
     def execute_session_command(self, session_id: str, req: SessionExecuteRequest) -> SessionExecuteResponse:
         """Executes a command in the session.
         
@@ -131,6 +138,7 @@ class Process:
             session_execute_request=req
         )
 
+    @intercept_exceptions(message_prefix="Failed to get session command logs: ")
     def get_session_command_logs(self, session_id: str, command_id: str) -> str:
         """Gets the logs for a command in the session.
         
@@ -147,6 +155,7 @@ class Process:
             command_id=command_id
         )
 
+    @intercept_exceptions(message_prefix="Failed to list sessions: ")
     def list_sessions(self) -> List[Session]:
         """Lists all sessions in the workspace.
         
@@ -157,6 +166,7 @@ class Process:
             workspace_id=self.instance.id
         )
 
+    @intercept_exceptions(message_prefix="Failed to delete session: ")
     def delete_session(self, session_id: str) -> None:
         """Deletes a session in the workspace.
         

--- a/packages/typescript/src/Daytona.ts
+++ b/packages/typescript/src/Daytona.ts
@@ -9,6 +9,7 @@ import {
   CreateWorkspaceTargetEnum,
 } from '@daytonaio/api-client'
 import { WorkspaceTsCodeToolbox } from './code-toolbox/WorkspaceTsCodeToolbox'
+import axios from 'axios'
 
 /**
  * Configuration options for initializing the Daytona client
@@ -116,8 +117,24 @@ export class Daytona {
       },
     })
 
-    this.workspaceApi = new WorkspaceApi(configuration)
-    this.toolboxApi = new ToolboxApi(configuration)
+    const axiosInstance = axios.create();
+    axiosInstance.interceptors.response.use(
+      (response) => {
+        return response
+      },
+      (error) => {
+        const errorMessage =
+          error.response?.data?.message ||
+          error.response?.data ||
+          error.message ||
+          String(error);
+
+        throw new Error(errorMessage);
+      }
+    )
+
+    this.workspaceApi = new WorkspaceApi(configuration, '', axiosInstance)
+    this.toolboxApi = new ToolboxApi(configuration, '', axiosInstance)
   }
 
   /**

--- a/packages/typescript/src/Daytona.ts
+++ b/packages/typescript/src/Daytona.ts
@@ -10,6 +10,7 @@ import {
 } from '@daytonaio/api-client'
 import { WorkspaceTsCodeToolbox } from './code-toolbox/WorkspaceTsCodeToolbox'
 import axios from 'axios'
+import { DaytonaError } from './errors/DaytonaError'
 
 /**
  * Configuration options for initializing the Daytona client
@@ -90,16 +91,16 @@ export class Daytona {
   /**
    * Creates a new Daytona client instance
    * @param {DaytonaConfig} [config] - Configuration options
-   * @throws {Error} When API key or server URL is missing
+   * @throws {DaytonaError} When API key or server URL is missing
    */
   constructor(config?: DaytonaConfig) {
     const apiKey = config?.apiKey || process.env.DAYTONA_API_KEY
     if (!apiKey) {
-      throw new Error('API key is required')
+      throw new DaytonaError('API key is required')
     }
     const serverUrl = config?.serverUrl || process.env.DAYTONA_SERVER_URL
     if (!serverUrl) {
-      throw new Error('Server URL is required')
+      throw new DaytonaError('Server URL is required')
     }
     const envTarget = process.env.DAYTONA_TARGET as CreateWorkspaceTargetEnum
     const target = config?.target || envTarget
@@ -129,7 +130,7 @@ export class Daytona {
           error.message ||
           String(error);
 
-        throw new Error(errorMessage);
+        throw new DaytonaError(errorMessage);
       }
     )
 
@@ -144,7 +145,7 @@ export class Daytona {
    */
   public async create(params?: CreateWorkspaceParams): Promise<Workspace> {
     if (params?.autoStopInterval !== undefined && (!Number.isInteger(params.autoStopInterval) || params.autoStopInterval < 0)) {
-      throw new Error('autoStopInterval must be a non-negative integer');
+      throw new DaytonaError('autoStopInterval must be a non-negative integer');
     }
 
     const workspaceId = params?.id || `sandbox-${uuidv4().slice(0, 8)}`
@@ -157,7 +158,7 @@ export class Daytona {
     }
 
     if (params?.timeout && params.timeout < 0) {
-      throw new Error('Timeout must be a non-negative number')
+      throw new DaytonaError('Timeout must be a non-negative number')
     }
 
     const response = await this.workspaceApi.createWorkspace({
@@ -214,7 +215,7 @@ export class Daytona {
     return response.data.map((workspace) => {
       const language = workspace.labels?.[`code-toolbox-language`] as CodeLanguage
       if (language && !['python', 'javascript', 'typescript'].includes(language)) {
-        throw new Error(`Invalid code-toolbox-language: ${language}`)
+        throw new DaytonaError(`Invalid code-toolbox-language: ${language}`)
       }
       return new Workspace(
         workspace.id, 
@@ -270,7 +271,7 @@ export class Daytona {
       case undefined:
         return new WorkspacePythonCodeToolbox()
       default:
-        throw new Error(`Unsupported language: ${language}`)
+        throw new DaytonaError(`Unsupported language: ${language}`)
     }
   }
 }

--- a/packages/typescript/src/Workspace.ts
+++ b/packages/typescript/src/Workspace.ts
@@ -5,6 +5,7 @@ import { Git } from './Git'
 //  import { LspLanguageId, LspServer } from './LspServer'
 import { Process } from './Process'
 import { LspLanguageId, LspServer } from './LspServer'
+import { DaytonaError } from './errors/DaytonaError'
 
 /**
  * Resources allocated to a workspace
@@ -139,7 +140,7 @@ export class Workspace {
    */
   public async start(timeout?: number): Promise<void> {
     if (timeout != undefined && timeout < 0) {
-      throw new Error('Timeout must be a non-negative number');
+      throw new DaytonaError('Timeout must be a non-negative number');
     }
     await this.workspaceApi.startWorkspace(this.instance.id)
     await this.waitUntilStarted(timeout)
@@ -164,7 +165,7 @@ export class Workspace {
 
   public async waitUntilStarted(timeout: number = 60) {
     if (timeout < 0) {
-      throw new Error('Timeout must be a non-negative number');
+      throw new DaytonaError('Timeout must be a non-negative number');
     }
 
     const checkInterval = 100; // Wait 100 ms between checks
@@ -179,13 +180,13 @@ export class Workspace {
       }
 
       if (state === 'error') {
-        throw new Error(`Workspace failed to start with status: ${state}`);
+        throw new DaytonaError(`Workspace failed to start with status: ${state}`);
       }
 
       await new Promise(resolve => setTimeout(resolve, checkInterval));
     }
 
-    throw new Error('Workspace failed to become ready within the timeout period');
+    throw new DaytonaError('Workspace failed to become ready within the timeout period');
   }
 
   public async waitUntilStopped() {
@@ -201,14 +202,14 @@ export class Workspace {
       }
 
       if (state === 'error') {
-        throw new Error(`Workspace failed to stop with status: ${state}`);
+        throw new DaytonaError(`Workspace failed to stop with status: ${state}`);
       }
 
       await new Promise(resolve => setTimeout(resolve, 100)); // Wait 100 ms between checks
       attempts++;
     }
 
-    throw new Error('Workspace failed to become stopped within the timeout period');
+    throw new DaytonaError('Workspace failed to become stopped within the timeout period');
   }
 
   /**
@@ -251,11 +252,11 @@ export class Workspace {
   /**
    * Sets the auto-stop interval for the workspace
    * @param {number} interval - Number of minutes after which the workspace will automatically stop (must be an integer). Set to 0 to disable auto-stop.
-   * @throws {Error} If interval is negative
+   * @throws {DaytonaError} If interval is negative
    */
   public async setAutostopInterval(interval: number): Promise<void> {
     if (!Number.isInteger(interval) || interval < 0) {
-      throw new Error('autoStopInterval must be a non-negative integer');
+      throw new DaytonaError('autoStopInterval must be a non-negative integer');
     }
     
     await this.workspaceApi.setAutostopInterval(this.id, interval)
@@ -266,13 +267,13 @@ export class Workspace {
    * Gets the preview link for the workspace at a specific port. If the port is not open, it will open it and return the link.
    * @param {number} port - The port to open the preview link on
    * @returns {string} The preview link for the workspace at the specified port
-   * @throws {Error} If the node domain is not found in the provider metadata
+   * @throws {DaytonaError} If the node domain is not found in the provider metadata
    */
   public getPreviewLink(port: number): string {
     const providerMetadata = JSON.parse(this.instance.info?.providerMetadata || '{}')
     const nodeDomain = providerMetadata.nodeDomain || ''
     if (!nodeDomain) {
-      throw new Error("Cannot get preview link. Node domain not found in provider metadata. Please contact support.")
+      throw new DaytonaError("Cannot get preview link. Node domain not found in provider metadata. Please contact support.")
     }
     return `https://${port}-${this.id}.${nodeDomain}`
   }

--- a/packages/typescript/src/errors/DaytonaError.ts
+++ b/packages/typescript/src/errors/DaytonaError.ts
@@ -1,0 +1,5 @@
+export class DaytonaError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -7,6 +7,7 @@ export { Git } from './Git'
 export { Process } from './Process'
 // export { LspServer } from './LspServer'
 // export type { LspLanguageId, Position } from './LspServer'
+export { DaytonaError } from './errors/DaytonaError'
 
 // Re-export necessary types from client
 export type {


### PR DESCRIPTION
## New python error printout:
```
Traceback (most recent call last):
  File "/workspaces/sdk/examples/python/exec-command/exec.py", line 14, in <module>
    workspace = daytona.create(params)
  File "/workspaces/sdk/packages/python/src/daytona_sdk/_utils/exceptions.py", line 27, in wrapper
    raise DaytonaException(f"{message_prefix}{message}") from None
daytona_sdk._utils.exceptions.DaytonaException: Failed to create workspace: Workspace quota exceeded. Maximum allowed: 0
```

## Old python error printout:
```
Traceback (most recent call last):
  File "/workspaces/sdk/examples/python/exec-command/exec.py", line 14, in <module>
    workspace = daytona.create(params)
  File "/workspaces/sdk/packages/python/src/daytona_sdk/daytona.py", line 178, in create
    raise e #Exception(f"Failed to create workspace: {parse_api_error(e)}") from None
  File "/workspaces/sdk/packages/python/src/daytona_sdk/daytona.py", line 155, in create
    response = self.workspace_api.create_workspace(create_workspace=workspace_data)
  File "/usr/local/python/3.10.16/lib/python3.10/site-packages/pydantic/_internal/_validate_call.py", line 38, in wrapper_function
    return wrapper(*args, **kwargs)
  File "/usr/local/python/3.10.16/lib/python3.10/site-packages/pydantic/_internal/_validate_call.py", line 111, in __call__
    res = self.__pydantic_validator__.validate_python(pydantic_core.ArgsKwargs(args, kwargs))
  File "/usr/local/python/3.10.16/lib/python3.10/site-packages/daytona_api_client/api/workspace_api.py", line 362, in create_workspace
    return self.api_client.response_deserialize(
  File "/usr/local/python/3.10.16/lib/python3.10/site-packages/daytona_api_client/api_client.py", line 322, in response_deserialize
    raise ApiException.from_response(
  File "/usr/local/python/3.10.16/lib/python3.10/site-packages/daytona_api_client/exceptions.py", line 142, in from_response
    raise BadRequestException(http_resp=http_resp, body=body, data=data)
daytona_api_client.exceptions.BadRequestException: (400)
Reason: Bad Request
HTTP response headers: HTTPHeaderDict({'Date': 'Tue, 25 Feb 2025 17:29:34 GMT', 'Content-Type': 'application/json; charset=utf-8', 'Content-Length': '160', 'Connection': 'keep-alive', 'X-Powered-By': 'Express', 'ETag': 'W/"a0-ptjFOWOh9I2WdD6hrw2xm1+mH7A"'})
HTTP response body: {"statusCode":400,"timestamp":"2025-02-25T17:29:34.749Z","path":"/api/workspace","error":"Bad Request","message":"Workspace quota exceeded. Maximum allowed: 0"}
```

## New typescript error printout:
```
DaytonaError: Workspace quota exceeded. Maximum allowed: 0
    at /workspaces/sdk/packages/typescript/dist/Daytona.js:55:19
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Axios.request (/workspaces/sdk/node_modules/axios/lib/core/Axios.js:40:14)
    at async Daytona.create (/workspaces/sdk/packages/typescript/dist/Daytona.js:79:26)
    at async main (/workspaces/sdk/examples/typescript/exec-command/src/index.ts:69:21)
```

## Old typescript error printout:
```
/workspaces/sdk/node_modules/axios/lib/core/settle.js:19
    reject(new AxiosError(
           ^
AxiosError: Request failed with status code 400
    at settle (/workspaces/sdk/node_modules/axios/lib/core/settle.js:19:12)
    at IncomingMessage.handleStreamEnd (/workspaces/sdk/node_modules/axios/lib/adapters/http.js:599:11)
    at IncomingMessage.emit (node:events:530:35)
    at IncomingMessage.emit (node:domain:488:12)
    at endReadableNT (node:internal/streams/readable:1696:12)
    at processTicksAndRejections (node:internal/process/task_queues:82:21)
    at Axios.request (/workspaces/sdk/node_modules/axios/lib/core/Axios.js:45:41)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Daytona.create (/workspaces/sdk/packages/typescript/dist/Daytona.js:63:26)
    at async main (/workspaces/sdk/examples/typescript/exec-command/src/index.ts:67:21) {
  code: 'ERR_BAD_REQUEST',
  config: {
    transitional: {
      silentJSONParsing: true,
      forcedJSONParsing: true,
      clarifyTimeoutError: false
    },
    adapter: [ 'xhr', 'http', 'fetch' ],
    transformRequest: [ [Function: transformRequest] ],
    transformResponse: [ [Function: transformResponse] ],
    timeout: 0,
    xsrfCookieName: 'XSRF-TOKEN',
    xsrfHeaderName: 'X-XSRF-TOKEN',
    maxContentLength: -1,
    maxBodyLength: -1,
    env: { FormData: [Function], Blob: [class Blob] },
    validateStatus: [Function: validateStatus],
    headers: Object [AxiosHeaders] {
      Accept: 'application/json, text/plain, */*',
      'Content-Type': 'application/json',
      Authorization: 'Bearer dtn_cf41ba33d05e455ab71fb38982501abc5f145e6f964230636c7810be285833d0',
      'User-Agent': 'axios/1.7.9',
      'Content-Length': '74',
      'Accept-Encoding': 'gzip, compress, deflate, br'
    },
    method: 'post',
    data: '{"id":"sandbox-540b8947","name":"sandbox-540b8947","env":{},"target":"eu"}',
    url: 'https://stage.daytona.work/api/workspace'
  },
  request: <ref *1> ClientRequest {
    _events: [Object: null prototype] {
      abort: [Function (anonymous)],
      aborted: [Function (anonymous)],
      connect: [Function (anonymous)],
      error: [Function (anonymous)],
      socket: [Function (anonymous)],
      timeout: [Function (anonymous)],
      finish: [Function: requestOnFinish]
    },
    _eventsCount: 7,
    _maxListeners: undefined,
    outputData: [],
    outputSize: 0,
    writable: true,
    destroyed: true,
    _last: false,
    chunkedEncoding: false,
    shouldKeepAlive: true,
    maxRequestsOnConnectionReached: false,
    _defaultKeepAlive: true,
    useChunkedEncodingByDefault: true,
    sendDate: false,
    _removedConnection: false,
    _removedContLen: false,
    _removedTE: false,
    strictContentLength: false,
    _contentLength: '74',
    _hasBody: true,
    _trailer: '',
    finished: true,
    _headerSent: true,
    _closed: true,
    socket: TLSSocket {
      _tlsOptions: [Object],
      _secureEstablished: true,
      _securePending: false,
      _newSessionPending: false,
      _controlReleased: true,
      secureConnecting: false,
      _SNICallback: null,
      servername: 'stage.daytona.work',
      alpnProtocol: false,
      authorized: true,
      authorizationError: null,
      encrypted: true,
      _events: [Object: null prototype],
      _eventsCount: 9,
      connecting: false,
      _hadError: false,
      _parent: null,
      _host: 'stage.daytona.work',
      _closeAfterHandlingError: false,
      _readableState: [ReadableState],
      _writableState: [WritableState],
      allowHalfOpen: false,
      _maxListeners: undefined,
      _sockname: null,
      _pendingData: null,
      _pendingEncoding: '',
      server: undefined,
      _server: null,
      ssl: [TLSWrap],
      _requestCert: true,
      _rejectUnauthorized: true,
      timeout: 5000,
      parser: null,
      _httpMessage: null,
      autoSelectFamilyAttemptedAddresses: [Array],
      [Symbol(alpncallback)]: null,
      [Symbol(res)]: [TLSWrap],
      [Symbol(verified)]: true,
      [Symbol(pendingSession)]: null,
      [Symbol(async_id_symbol)]: -1,
      [Symbol(kHandle)]: [TLSWrap],
      [Symbol(lastWriteQueueSize)]: 0,
      [Symbol(timeout)]: [Timeout],
      [Symbol(kBuffer)]: null,
      [Symbol(kBufferCb)]: null,
      [Symbol(kBufferGen)]: null,
      [Symbol(shapeMode)]: true,
      [Symbol(kCapture)]: false,
      [Symbol(kSetNoDelay)]: false,
      [Symbol(kSetKeepAlive)]: true,
      [Symbol(kSetKeepAliveInitialDelay)]: 1,
      [Symbol(kBytesRead)]: 0,
      [Symbol(kBytesWritten)]: 0,
      [Symbol(connect-options)]: [Object]
    },
    _header: 'POST /api/workspace HTTP/1.1\r\n' +
      'Accept: application/json, text/plain, */*\r\n' +
      'Content-Type: application/json\r\n' +
      'Authorization: Bearer dtn_cf41ba33d05e455ab71fb38982501abc5f145e6f964230636c7810be285833d0\r\n' +
      'User-Agent: axios/1.7.9\r\n' +
      'Content-Length: 74\r\n' +
      'Accept-Encoding: gzip, compress, deflate, br\r\n' +
      'Host: stage.daytona.work\r\n' +
      'Connection: keep-alive\r\n' +
      '\r\n',
    _keepAliveTimeout: 0,
    _onPendingData: [Function: nop],
    agent: Agent {
      _events: [Object: null prototype],
      _eventsCount: 2,
      _maxListeners: undefined,
      defaultPort: 443,
      protocol: 'https:',
      options: [Object: null prototype],
      requests: [Object: null prototype] {},
      sockets: [Object: null prototype] {},
      freeSockets: [Object: null prototype],
      keepAliveMsecs: 1000,
      keepAlive: true,
      maxSockets: Infinity,
      maxFreeSockets: 256,
      scheduling: 'lifo',
      maxTotalSockets: Infinity,
      totalSocketCount: 1,
      maxCachedSessions: 100,
      _sessionCache: [Object],
      [Symbol(shapeMode)]: false,
      [Symbol(kCapture)]: false
    },
    socketPath: undefined,
    method: 'POST',
    maxHeaderSize: undefined,
    insecureHTTPParser: undefined,
    joinDuplicateHeaders: undefined,
    path: '/api/workspace',
    _ended: true,
    res: IncomingMessage {
      _events: [Object],
      _readableState: [ReadableState],
      _maxListeners: undefined,
      socket: null,
      httpVersionMajor: 1,
      httpVersionMinor: 1,
      httpVersion: '1.1',
      complete: true,
      rawHeaders: [Array],
      rawTrailers: [],
      joinDuplicateHeaders: undefined,
      aborted: false,
      upgrade: false,
      url: '',
      method: null,
      statusCode: 400,
      statusMessage: 'Bad Request',
      client: [TLSSocket],
      _consuming: false,
      _dumped: false,
      req: [Circular *1],
      _eventsCount: 4,
      responseUrl: 'https://stage.daytona.work/api/workspace',
      redirects: [],
      [Symbol(shapeMode)]: true,
      [Symbol(kCapture)]: false,
      [Symbol(kHeaders)]: [Object],
      [Symbol(kHeadersCount)]: 12,
      [Symbol(kTrailers)]: null,
      [Symbol(kTrailersCount)]: 0
    },
    aborted: false,
    timeoutCb: null,
    upgradeOrConnect: false,
    parser: null,
    maxHeadersCount: null,
    reusedSocket: false,
    host: 'stage.daytona.work',
    protocol: 'https:',
    _redirectable: Writable {
      _events: [Object],
      _writableState: [WritableState],
      _maxListeners: undefined,
      _options: [Object],
      _ended: true,
      _ending: true,
      _redirectCount: 0,
      _redirects: [],
      _requestBodyLength: 74,
      _requestBodyBuffers: [],
      _eventsCount: 3,
      _onNativeResponse: [Function (anonymous)],
      _currentRequest: [Circular *1],
      _currentUrl: 'https://stage.daytona.work/api/workspace',
      [Symbol(shapeMode)]: true,
      [Symbol(kCapture)]: false
    },
    [Symbol(shapeMode)]: false,
    [Symbol(kCapture)]: false,
    [Symbol(kBytesWritten)]: 0,
    [Symbol(kNeedDrain)]: false,
    [Symbol(corked)]: 0,
    [Symbol(kOutHeaders)]: [Object: null prototype] {
      accept: [Array],
      'content-type': [Array],
      authorization: [Array],
      'user-agent': [Array],
      'content-length': [Array],
      'accept-encoding': [Array],
      host: [Array]
    },
    [Symbol(errored)]: null,
    [Symbol(kHighWaterMark)]: 16384,
    [Symbol(kRejectNonStandardBodyWrites)]: false,
    [Symbol(kUniqueHeaders)]: null
  },
  response: {
    status: 400,
    statusText: 'Bad Request',
    headers: Object [AxiosHeaders] {
      date: 'Tue, 25 Feb 2025 16:15:56 GMT',
      'content-type': 'application/json; charset=utf-8',
      'content-length': '160',
      connection: 'keep-alive',
      'x-powered-by': 'Express',
      etag: 'W/"a0-nTwRZXda+PCarnG9DRZe0ntlqEs"'
    },
    config: {
      transitional: [Object],
      adapter: [Array],
      transformRequest: [Array],
      transformResponse: [Array],
      timeout: 0,
      xsrfCookieName: 'XSRF-TOKEN',
      xsrfHeaderName: 'X-XSRF-TOKEN',
      maxContentLength: -1,
      maxBodyLength: -1,
      env: [Object],
      validateStatus: [Function: validateStatus],
      headers: [Object [AxiosHeaders]],
      method: 'post',
      data: '{"id":"sandbox-540b8947","name":"sandbox-540b8947","env":{},"target":"eu"}',
      url: 'https://stage.daytona.work/api/workspace'
    },
    request: <ref *1> ClientRequest {
      _events: [Object: null prototype],
      _eventsCount: 7,
      _maxListeners: undefined,
      outputData: [],
      outputSize: 0,
      writable: true,
      destroyed: true,
      _last: false,
      chunkedEncoding: false,
      shouldKeepAlive: true,
      maxRequestsOnConnectionReached: false,
      _defaultKeepAlive: true,
      useChunkedEncodingByDefault: true,
      sendDate: false,
      _removedConnection: false,
      _removedContLen: false,
      _removedTE: false,
      strictContentLength: false,
      _contentLength: '74',
      _hasBody: true,
      _trailer: '',
      finished: true,
      _headerSent: true,
      _closed: true,
      socket: [TLSSocket],
      _header: 'POST /api/workspace HTTP/1.1\r\n' +
        'Accept: application/json, text/plain, */*\r\n' +
        'Content-Type: application/json\r\n' +
        'Authorization: Bearer dtn_cf41ba33d05e455ab71fb38982501abc5f145e6f964230636c7810be285833d0\r\n' +
        'User-Agent: axios/1.7.9\r\n' +
        'Content-Length: 74\r\n' +
        'Accept-Encoding: gzip, compress, deflate, br\r\n' +
        'Host: stage.daytona.work\r\n' +
        'Connection: keep-alive\r\n' +
        '\r\n',
      _keepAliveTimeout: 0,
      _onPendingData: [Function: nop],
      agent: [Agent],
      socketPath: undefined,
      method: 'POST',
      maxHeaderSize: undefined,
      insecureHTTPParser: undefined,
      joinDuplicateHeaders: undefined,
      path: '/api/workspace',
      _ended: true,
      res: [IncomingMessage],
      aborted: false,
      timeoutCb: null,
      upgradeOrConnect: false,
      parser: null,
      maxHeadersCount: null,
      reusedSocket: false,
      host: 'stage.daytona.work',
      protocol: 'https:',
      _redirectable: [Writable],
      [Symbol(shapeMode)]: false,
      [Symbol(kCapture)]: false,
      [Symbol(kBytesWritten)]: 0,
      [Symbol(kNeedDrain)]: false,
      [Symbol(corked)]: 0,
      [Symbol(kOutHeaders)]: [Object: null prototype],
      [Symbol(errored)]: null,
      [Symbol(kHighWaterMark)]: 16384,
      [Symbol(kRejectNonStandardBodyWrites)]: false,
      [Symbol(kUniqueHeaders)]: null
    },
    data: {
      statusCode: 400,
      timestamp: '2025-02-25T16:15:56.334Z',
      path: '/api/workspace',
      error: 'Bad Request',
      message: 'Workspace quota exceeded. Maximum allowed: 0'
    }
  },
  status: 400
}
```