### PR TITLE
fix: preserve python type hints and method specification

### DIFF
--- a/packages/python/src/daytona_sdk/_utils/errors.py
+++ b/packages/python/src/daytona_sdk/_utils/errors.py
@@ -1,20 +1,24 @@
 import json
 import functools
-from typing import Callable, Optional
+from typing import Callable, Optional, TypeVar, Any, ParamSpec
 from daytona_api_client.exceptions import OpenApiException
 from daytona_sdk.common.errors import DaytonaError
 
 
-def intercept_errors(message_prefix: Optional[str] = ""):
+P = ParamSpec('P')
+T = TypeVar('T')
+
+
+def intercept_errors(message_prefix: str = "") -> Callable[[Callable[P, T]], Callable[P, T]]:
     """Decorator to intercept errors, process them, and optionally add a message prefix.
     If the error is an OpenApiException, it will be processed to extract the most meaningful error message.
 
     Args:
-        message_prefix (Optional[str]): Custom message prefix for the error.
+        message_prefix (str): Custom message prefix for the error.
     """
-    def decorator(func: Callable):
+    def decorator(func: Callable[P, T]) -> Callable[P, T]:
         @functools.wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             try:
                 return func(*args, **kwargs)
             except OpenApiException as e:

--- a/packages/python/src/daytona_sdk/_utils/timeout.py
+++ b/packages/python/src/daytona_sdk/_utils/timeout.py
@@ -1,19 +1,23 @@
 import functools
 import concurrent.futures
-from typing import Callable, Optional, Any
+from typing import Callable, Optional, Any, TypeVar, ParamSpec
 from daytona_sdk._utils.errors import DaytonaError
 
 
-def with_timeout(error_message: Optional[Callable[[Any, float], str]] = None):
+P = ParamSpec('P')
+T = TypeVar('T')
+
+
+def with_timeout(error_message: Optional[Callable[[Any, float], str]] = None) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """Decorator to add a timeout mechanism with an optional custom error message.
 
     Args:
         error_message (Optional[Callable[[Any, float], str]]): A callable that accepts `self` and `timeout`,
                                                                and returns a string error message.
     """
-    def decorator(func):
+    def decorator(func: Callable[P, T]) -> Callable[P, T]:
         @functools.wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             # Get function argument names
             arg_names = func.__code__.co_varnames[:func.__code__.co_argcount]
             arg_dict = dict(zip(arg_names, args))


### PR DESCRIPTION
All Python methods that use custom decorators lack type hints and method specifications, for example:
![Pasted Graphic 3](https://github.com/user-attachments/assets/d5f1ee48-12ad-45aa-9c86-a03ac93065a1)


This significantly impacts the developer experience. This PR fixes that issue:
![Pasted Graphic 5](https://github.com/user-attachments/assets/4a982f8a-feef-4fe5-84aa-3d6700b26873)
