### PR TITLE
make sure SDK docs pages have titles

### DIFF
--- a/docs/python-sdk/charts.mdx
+++ b/docs/python-sdk/charts.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Chart"
+title: "Charts"
 hideTitleOnPage: true
 ---
 ## Chart

--- a/docs/python-sdk/charts.mdx
+++ b/docs/python-sdk/charts.mdx
@@ -1,7 +1,6 @@
 ---
-title: ""
+title: "Chart"
 ---
-
 ## Chart
 
 ```python
@@ -16,7 +15,6 @@ Represents a chart with metadata from matplotlib.
 - `title` _str_ - The title of the chart
 - `elements` _List[Any]_ - The elements of the chart
 - `png` _Optional[str]_ - The PNG representation of the chart encoded in base64
-
 
 ## ChartType
 

--- a/docs/python-sdk/charts.mdx
+++ b/docs/python-sdk/charts.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Chart"
+hideTitleOnPage: true
 ---
 ## Chart
 

--- a/docs/python-sdk/code-run-params.mdx
+++ b/docs/python-sdk/code-run-params.mdx
@@ -1,7 +1,6 @@
 ---
-title: ""
+title: "CodeRunParams"
 ---
-
 ## CodeRunParams
 
 ```python
@@ -15,5 +14,4 @@ Parameters for code execution.
 
 - `argv` _Optional[List[str]]_ - Command line arguments
 - `env` _Optional[Dict[str, str]]_ - Environment variables
-
 

--- a/docs/python-sdk/code-run-params.mdx
+++ b/docs/python-sdk/code-run-params.mdx
@@ -1,5 +1,6 @@
 ---
 title: "CodeRunParams"
+hideTitleOnPage: true
 ---
 ## CodeRunParams
 

--- a/docs/python-sdk/daytona.mdx
+++ b/docs/python-sdk/daytona.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Daytona"
+hideTitleOnPage: true
 ---
 ## Daytona
 

--- a/docs/python-sdk/daytona.mdx
+++ b/docs/python-sdk/daytona.mdx
@@ -1,7 +1,6 @@
 ---
-title: ""
+title: "Daytona"
 ---
-
 ## Daytona
 
 ```python
@@ -263,7 +262,6 @@ Stops a Sandbox and waits for it to be stopped.
 **Raises**:
 
 - `DaytonaError` - If timeout is negative; If Sandbox fails to stop or times out
-
 
 ## CodeLanguage
 

--- a/docs/python-sdk/errors.mdx
+++ b/docs/python-sdk/errors.mdx
@@ -1,5 +1,5 @@
 ---
-title: "DaytonaError"
+title: "Errors"
 hideTitleOnPage: true
 ---
 ## DaytonaError

--- a/docs/python-sdk/errors.mdx
+++ b/docs/python-sdk/errors.mdx
@@ -1,5 +1,6 @@
 ---
 title: "DaytonaError"
+hideTitleOnPage: true
 ---
 ## DaytonaError
 

--- a/docs/python-sdk/errors.mdx
+++ b/docs/python-sdk/errors.mdx
@@ -1,7 +1,6 @@
 ---
-title: ""
+title: "DaytonaError"
 ---
-
 ## DaytonaError
 
 ```python
@@ -9,5 +8,4 @@ class DaytonaError(Exception)
 ```
 
 Base error for Daytona SDK.
-
 

--- a/docs/python-sdk/execute-response.mdx
+++ b/docs/python-sdk/execute-response.mdx
@@ -1,5 +1,6 @@
 ---
 title: "ExecuteResponse"
+hideTitleOnPage: true
 ---
 ## ExecuteResponse
 

--- a/docs/python-sdk/execute-response.mdx
+++ b/docs/python-sdk/execute-response.mdx
@@ -1,7 +1,6 @@
 ---
-title: ""
+title: "ExecuteResponse"
 ---
-
 ## ExecuteResponse
 
 ```python
@@ -15,7 +14,6 @@ Response from the command execution.
 - `exit_code` _int_ - The exit code from the command execution
 - `result` _str_ - The output from the command execution
 - `artifacts` _Optional[ExecutionArtifacts]_ - Artifacts from the command execution
-
 
 ## ExecutionArtifacts
 

--- a/docs/python-sdk/file-system.mdx
+++ b/docs/python-sdk/file-system.mdx
@@ -1,7 +1,6 @@
 ---
-title: ""
+title: "FileSystem"
 ---
-
 ## FileSystem
 
 ```python
@@ -413,5 +412,4 @@ data = {"key": "value"}
 content = json.dumps(data).encode('utf-8')
 sandbox.fs.upload_file("/workspace/data/config.json", content)
 ```
-
 

--- a/docs/python-sdk/file-system.mdx
+++ b/docs/python-sdk/file-system.mdx
@@ -1,5 +1,6 @@
 ---
 title: "FileSystem"
+hideTitleOnPage: true
 ---
 ## FileSystem
 

--- a/docs/python-sdk/git.mdx
+++ b/docs/python-sdk/git.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Git"
+hideTitleOnPage: true
 ---
 ## Git
 

--- a/docs/python-sdk/git.mdx
+++ b/docs/python-sdk/git.mdx
@@ -1,7 +1,6 @@
 ---
-title: ""
+title: "Git"
 ---
-
 ## Git
 
 ```python
@@ -295,7 +294,6 @@ print(f"On branch: {status.current_branch}")
 print(f"Commits ahead: {status.ahead}")
 print(f"Commits behind: {status.behind}")
 ```
-
 
 ## GitCommitResponse
 

--- a/docs/python-sdk/lsp-server.mdx
+++ b/docs/python-sdk/lsp-server.mdx
@@ -1,5 +1,6 @@
 ---
 title: "LspServer"
+hideTitleOnPage: true
 ---
 ## LspServer
 

--- a/docs/python-sdk/lsp-server.mdx
+++ b/docs/python-sdk/lsp-server.mdx
@@ -1,7 +1,6 @@
 ---
-title: ""
+title: "LspServer"
 ---
-
 ## LspServer
 
 ```python
@@ -246,7 +245,6 @@ completions = lsp.completions("/workspace/project/src/index.ts", pos)
 for item in completions.items:
     print(f"{item.label} ({item.kind}): {item.detail}")
 ```
-
 
 ## LspLanguageId
 

--- a/docs/python-sdk/process.mdx
+++ b/docs/python-sdk/process.mdx
@@ -1,7 +1,6 @@
 ---
-title: ""
+title: "Process"
 ---
-
 ## Process
 
 ```python
@@ -397,7 +396,6 @@ sandbox.process.create_session("temp-session")
 # Clean up when done
 sandbox.process.delete_session("temp-session")
 ```
-
 
 ## CodeRunParams
 

--- a/docs/python-sdk/process.mdx
+++ b/docs/python-sdk/process.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Process"
+hideTitleOnPage: true
 ---
 ## Process
 

--- a/docs/python-sdk/sandbox.mdx
+++ b/docs/python-sdk/sandbox.mdx
@@ -1,7 +1,6 @@
 ---
-title: ""
+title: "Sandbox"
 ---
-
 ## Sandbox
 
 ```python
@@ -373,7 +372,6 @@ Converts an API Sandbox instance to a SandboxInfo object.
 **Returns**:
 
 - `SandboxInfo` - The converted SandboxInfo object
-
 
 ## SandboxTargetRegion
 

--- a/docs/python-sdk/sandbox.mdx
+++ b/docs/python-sdk/sandbox.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Sandbox"
+hideTitleOnPage: true
 ---
 ## Sandbox
 

--- a/docs/typescript-sdk/charts.mdx
+++ b/docs/typescript-sdk/charts.mdx
@@ -1,5 +1,5 @@
 ---
-title: "ChartType"
+title: "Charts"
 hideTitleOnPage: true
 ---
 

--- a/docs/typescript-sdk/charts.mdx
+++ b/docs/typescript-sdk/charts.mdx
@@ -1,5 +1,5 @@
 ---
-title: ""
+title: "ChartType"
 ---
 
 

--- a/docs/typescript-sdk/charts.mdx
+++ b/docs/typescript-sdk/charts.mdx
@@ -1,5 +1,6 @@
 ---
 title: "ChartType"
+hideTitleOnPage: true
 ---
 
 

--- a/docs/typescript-sdk/daytona.mdx
+++ b/docs/typescript-sdk/daytona.mdx
@@ -1,5 +1,5 @@
 ---
-title: ""
+title: "Daytona"
 ---
 
 

--- a/docs/typescript-sdk/daytona.mdx
+++ b/docs/typescript-sdk/daytona.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Daytona"
+hideTitleOnPage: true
 ---
 
 

--- a/docs/typescript-sdk/errors.mdx
+++ b/docs/typescript-sdk/errors.mdx
@@ -1,5 +1,5 @@
 ---
-title: ""
+title: "DaytonaError"
 ---
 
 

--- a/docs/typescript-sdk/errors.mdx
+++ b/docs/typescript-sdk/errors.mdx
@@ -1,5 +1,5 @@
 ---
-title: "DaytonaError"
+title: "Errors"
 hideTitleOnPage: true
 ---
 

--- a/docs/typescript-sdk/errors.mdx
+++ b/docs/typescript-sdk/errors.mdx
@@ -1,5 +1,6 @@
 ---
 title: "DaytonaError"
+hideTitleOnPage: true
 ---
 
 

--- a/docs/typescript-sdk/execute-response.mdx
+++ b/docs/typescript-sdk/execute-response.mdx
@@ -1,5 +1,6 @@
 ---
 title: "ExecuteResponse"
+hideTitleOnPage: true
 ---
 
 

--- a/docs/typescript-sdk/execute-response.mdx
+++ b/docs/typescript-sdk/execute-response.mdx
@@ -1,5 +1,5 @@
 ---
-title: ""
+title: "ExecuteResponse"
 ---
 
 

--- a/docs/typescript-sdk/file-system.mdx
+++ b/docs/typescript-sdk/file-system.mdx
@@ -1,5 +1,6 @@
 ---
 title: "FileSystem"
+hideTitleOnPage: true
 ---
 
 

--- a/docs/typescript-sdk/file-system.mdx
+++ b/docs/typescript-sdk/file-system.mdx
@@ -1,5 +1,5 @@
 ---
-title: ""
+title: "FileSystem"
 ---
 
 

--- a/docs/typescript-sdk/git.mdx
+++ b/docs/typescript-sdk/git.mdx
@@ -1,5 +1,5 @@
 ---
-title: ""
+title: "Git"
 ---
 
 

--- a/docs/typescript-sdk/git.mdx
+++ b/docs/typescript-sdk/git.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Git"
+hideTitleOnPage: true
 ---
 
 

--- a/docs/typescript-sdk/lsp-server.mdx
+++ b/docs/typescript-sdk/lsp-server.mdx
@@ -1,5 +1,6 @@
 ---
 title: "LspServer"
+hideTitleOnPage: true
 ---
 
 

--- a/docs/typescript-sdk/lsp-server.mdx
+++ b/docs/typescript-sdk/lsp-server.mdx
@@ -1,5 +1,5 @@
 ---
-title: ""
+title: "LspServer"
 ---
 
 

--- a/docs/typescript-sdk/process.mdx
+++ b/docs/typescript-sdk/process.mdx
@@ -1,5 +1,5 @@
 ---
-title: ""
+title: "CodeRunParams"
 ---
 
 

--- a/docs/typescript-sdk/process.mdx
+++ b/docs/typescript-sdk/process.mdx
@@ -1,5 +1,5 @@
 ---
-title: "CodeRunParams"
+title: "Process"
 hideTitleOnPage: true
 ---
 

--- a/docs/typescript-sdk/process.mdx
+++ b/docs/typescript-sdk/process.mdx
@@ -1,5 +1,6 @@
 ---
 title: "CodeRunParams"
+hideTitleOnPage: true
 ---
 
 

--- a/docs/typescript-sdk/sandbox.mdx
+++ b/docs/typescript-sdk/sandbox.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Sandbox"
+hideTitleOnPage: true
 ---
 
 

--- a/docs/typescript-sdk/sandbox.mdx
+++ b/docs/typescript-sdk/sandbox.mdx
@@ -1,5 +1,5 @@
 ---
-title: ""
+title: "Sandbox"
 ---
 
 

--- a/packages/python/pydoc-markdown.yml
+++ b/packages/python/pydoc-markdown.yml
@@ -10,7 +10,12 @@ hooks:
   pre-render:
     - mkdir -p "$(dirname "$OUTPUT_FILE")"
   post-render:
-    -  #@ f"sed -i '1i ---\\ntitle: \"\"\\n---\\n' \"{env.OUTPUT_FILE}\""
+    - |
+      sed -i.bak "1i\\
+      ---\\
+      title: \"$FIRST_SECTION\"\\
+      ---\\
+      " "$OUTPUT_FILE" && rm -f "$OUTPUT_FILE.bak"
     - ./scripts/docs-reorder-sections.sh "$OUTPUT_FILE" #@ env.FIRST_SECTION or ""
     - ./scripts/docs-code-block-indentation.sh "$OUTPUT_FILE"
 

--- a/packages/python/pydoc-markdown.yml
+++ b/packages/python/pydoc-markdown.yml
@@ -13,7 +13,7 @@ hooks:
     - |
       sed -i.bak "1i\\
       ---\\
-      title: \"$FIRST_SECTION\"\\
+      title: \"$(basename "$OUTPUT_FILE" .mdx | awk '{for(i=1;i<=NF;i++){ $i=toupper(substr($i,1,1)) substr($i,2) }}1' FS='-' OFS='')\"\\
       hideTitleOnPage: true\\
       ---\\
       " "$OUTPUT_FILE" && rm -f "$OUTPUT_FILE.bak"

--- a/packages/python/pydoc-markdown.yml
+++ b/packages/python/pydoc-markdown.yml
@@ -14,6 +14,7 @@ hooks:
       sed -i.bak "1i\\
       ---\\
       title: \"$FIRST_SECTION\"\\
+      hideTitleOnPage: true\\
       ---\\
       " "$OUTPUT_FILE" && rm -f "$OUTPUT_FILE.bak"
     - ./scripts/docs-reorder-sections.sh "$OUTPUT_FILE" #@ env.FIRST_SECTION or ""

--- a/packages/typescript/hooks/typedoc-custom.mjs
+++ b/packages/typescript/hooks/typedoc-custom.mjs
@@ -8,13 +8,26 @@ import { MarkdownPageEvent } from 'typedoc-plugin-markdown'
 export function load(app) {
   // --- TITLE HACK ---
   app.renderer.markdownHooks.on('page.begin', () => {
+    // We'll add the title later in the END event
     return '---\ntitle: ""\n---\n'
   })
 
   // --- CONTENT HACKS ---
   app.renderer.on(MarkdownPageEvent.END, (page) => {
+
     if (!page.contents) return
 
+    let title = '';
+  
+    // Look for the first heading (## or ###)
+    const headingMatch = page.contents.match(/^#{2,3}\s+(.+)$/m);
+    if (headingMatch) {
+      title = headingMatch[1].trim();
+    }
+    
+    // Replace the empty title with the actual title
+    page.contents = page.contents.replace(/title: ""/, `title: "${title}"`);
+    
     page.contents = transformContent(page.contents)
     page.filename = transformFilename(page.filename)
   })

--- a/packages/typescript/hooks/typedoc-custom.mjs
+++ b/packages/typescript/hooks/typedoc-custom.mjs
@@ -9,7 +9,7 @@ export function load(app) {
   // --- TITLE HACK ---
   app.renderer.markdownHooks.on('page.begin', () => {
     // We'll add the title later in the END event
-    return '---\ntitle: ""\n---\n'
+    return '---\ntitle: ""\nhideTitleOnPage: true\n---\n'
   })
 
   // --- CONTENT HACKS ---

--- a/packages/typescript/hooks/typedoc-custom.mjs
+++ b/packages/typescript/hooks/typedoc-custom.mjs
@@ -14,15 +14,20 @@ export function load(app) {
 
   // --- CONTENT HACKS ---
   app.renderer.on(MarkdownPageEvent.END, (page) => {
-
     if (!page.contents) return
 
+    // Extract title from filename and capitalize first letter of each word
     let title = '';
-  
-    // Look for the first heading (## or ###)
-    const headingMatch = page.contents.match(/^#{2,3}\s+(.+)$/m);
-    if (headingMatch) {
-      title = headingMatch[1].trim();
+    if (page.filename) {
+      const filename = page.filename;
+      // Get the last part of the filename (after the last dot)
+      const baseFilename = filename.split('/').pop()?.replace(/\.md$/, '').split('.').pop() || '';
+      // Split into words and capitalize each word
+      const words = baseFilename.split(/[-_]/);
+      title = words.map(word => {
+        if (word.length === 0) return '';
+        return word.charAt(0).toUpperCase() + word.slice(1);
+      }).join('');
     }
     
     // Replace the empty title with the actual title


### PR DESCRIPTION
The purpose of this PR is to address the issue raised by https://github.com/daytonaio/docs/issues/298. 

Currently, when users visit pages such as https://www.daytona.io/docs/python-sdk/daytona/ or https://www.daytona.io/docs/typescript-sdk/daytona/, their browser tab bar shows `| Daytona`. 

This is because when the documentation markdown files are created, the title field of the front-matter is explicitly set to be an empty string: https://github.com/daytonaio/sdk/blob/d716ae4ff0a476059d4d81e123dc4a2a4b3f876c/packages/typescript/hooks/typedoc-custom.mjs#L11 and  https://github.com/daytonaio/sdk/blob/d716ae4ff0a476059d4d81e123dc4a2a4b3f876c/packages/python/pydoc-markdown.yml#L13

When these markdown files are converted into the web app that serves the documentation, this empty string is being passed as the value of the title field for that page, along with a `| Daytona` decorator that is appended to all page titles. 

In order to ensure that each generated Markdown page has a relevant title, I have made two changes. On the Python side, I changed the `sed` command to use the very convenient `FIRST_SECTION` environment variable that is passed to every invocation of `pydoc-markdown` command. 

On the Typescript side it was a bit more complicated because the `typedoc` command that generates the Markdown documentation files is not passed a handy environment variable with a relevant name. However, once the Markdown file is generated, we can just grab the value of the first heading and use that as the title. 

I tested this PR by executing `npm run docs` in my local environment and ensuring that each generated Markdown file had a relevant title in the front matter. 
