### PR TITLE
fix: use GB values for memory in examples

### DIFF
--- a/docs/python-sdk/daytona.mdx
+++ b/docs/python-sdk/daytona.mdx
@@ -118,7 +118,7 @@ params = CreateSandboxParams(
     language="python",
     image="debian:12.9",
     env_vars={"DEBUG": "true"},
-    resources=SandboxResources(cpu=2, memory=4096),
+    resources=SandboxResources(cpu=2, memory=4),
     auto_stop_interval=0
 )
 sandbox = daytona.create(params, 40)

--- a/packages/python/src/daytona_sdk/daytona.py
+++ b/packages/python/src/daytona_sdk/daytona.py
@@ -358,7 +358,7 @@ class Daytona:
                 language="python",
                 image="debian:12.9",
                 env_vars={"DEBUG": "true"},
-                resources=SandboxResources(cpu=2, memory=4096),
+                resources=SandboxResources(cpu=2, memory=4),
                 auto_stop_interval=0
             )
             sandbox = daytona.create(params, 40)


### PR DESCRIPTION
closes #71 