### PR TITLE
Consider the case of arrayBuffer in downloadFile

### DIFF
--- a/packages/typescript/src/FileSystem.ts
+++ b/packages/typescript/src/FileSystem.ts
@@ -139,6 +139,11 @@ export class FileSystem {
       if (Buffer.isBuffer(data)) {
         return data
       }
+
+      if (data instanceof ArrayBuffer) {
+        return Buffer.from(data)
+      }
+
       return Buffer.from(await data.arrayBuffer())
     }
 


### PR DESCRIPTION
In the Cloudflare workers environment, the response is returned as an arrayBuffer.
This was causing the error `data.arrayBuffer is not a function`.